### PR TITLE
Fix the vmin, vmax range of the keepout map

### DIFF
--- a/src/roman_pointing/roman_observability.py
+++ b/src/roman_pointing/roman_observability.py
@@ -383,6 +383,8 @@ def plot_keepout(keepout_dict, ts):
         komap_int,
         cmap=cmap,
         shading="flat",
+        vmin=0,
+        vmax=1,
     )
 
     ax.set_yticks(np.arange(num_targets) + 0.5)


### PR DESCRIPTION
Fix to address https://github.com/roman-corgi/roman_pointing/issues/23