### PR TITLE
Issue 26 corgi

### DIFF
--- a/src/roman_pointing/Reference_Star_Selection_Tool.py
+++ b/src/roman_pointing/Reference_Star_Selection_Tool.py
@@ -210,7 +210,7 @@ def get_science_target_diameter(sci_name, sci_coord, band):
         print(f"  Science target diameter: {val:.4f} mas  [{src}]")
         return val, src
 
-    except Exception as exc:
+    except (requests.RequestException, KeyError, ValueError) as exc:
         print(f"  Warning: VizieR query failed for '{sci_name}': {exc} — diameter unavailable.")
         return None, None
 
@@ -397,20 +397,20 @@ def load_catalog(
     resolved_cache = Path(cache_path) if cache_path else DEFAULT_CACHE_PATH
 
     if not force_refresh and cache_is_fresh(resolved_cache, max_cache_age_hours):
-        print(f"Loading catalog from cache ({resolved_cache.name})...")
+        print(f"Loading CORGI reference star catalog from cache ({resolved_cache.name})...")
         df = pd.read_csv(resolved_cache, low_memory=False)
-        print(f"Catalog loaded: {len(df)} reference star(s).")
+        print(f"  CORGI catalog loaded: {len(df)} reference star(s).")
         return df
 
     fetch_error = None
-    print(f"Fetching catalog from {url} ...")
+    print(f"Fetching CORGI reference star catalog from {url} ...")
     try:
         df = fetch_catalog(url)
         df = coerce_catalog(df)
         resolved_cache.parent.mkdir(parents=True, exist_ok=True)
         df.to_csv(resolved_cache, index=False)
-        print(f"  Catalog cached → {resolved_cache}")
-        print(f"Catalog loaded: {len(df)} reference star(s).")
+        print(f"  CORGI catalog cached → {resolved_cache}")
+        print(f"  CORGI catalog loaded: {len(df)} reference star(s).")
         return df
     except Exception as exc:
         fetch_error = exc
@@ -423,7 +423,7 @@ def load_catalog(
             stacklevel=2,
         )
         df = pd.read_csv(resolved_cache, low_memory=False)
-        print(f"Catalog loaded from stale cache: {len(df)} reference star(s).")
+        print(f"  CORGI catalog loaded from stale cache: {len(df)} reference star(s).")
         return df
 
     raise RuntimeError(
@@ -431,42 +431,23 @@ def load_catalog(
         f"and no cache exists at {resolved_cache}."
     )
 
-def get_science_mag(sci_name, band, catalog=None, engine=None):
-    """Look up the science target magnitude from the catalog or corgidb star endpoint.
+def get_science_mag(sci_name, band, engine=None):
+    """Look up the science target magnitude from the corgidb individual-star endpoint.
+
     Args:
-        sci_name (str): SIMBAD-resolvable science target name, e.g. '47 Uma'.
+        sci_name (str): Science target name, e.g. '47 Uma'.
         band (int or str): Photometric band — 1 (V-band NFB), '1w' (V-band
             Wide FOV), 3 (I-band Spec), or 4 (I-band Wide FOV).
-        catalog (pandas.DataFrame, optional): Loaded reference star catalog
-            from load_catalog(). If None, the catalog lookup is skipped and
-            fetch_star.php is queried directly.
         engine: Ignored. Kept for backwards compatibility.
 
     Returns:
         float or None: Magnitude value in the appropriate band, or None if
-            not found in either the catalog or the star endpoint.
+            not found.
     """
     mag_col = "sy_vmag" if band in (1, "1w") else "sy_imag"
     band_label = BAND_LABEL.get(band, "?")
 
-    # 1) Try the ref catalog first (works if science target is also a ref star)
-    if catalog is not None:
-        sci_norm = sci_name.strip().lower().lstrip("* ")
-        mask = (
-            catalog["main_id"].astype(str).str.strip().str.lstrip("* ").str.lower() == sci_norm
-        ) | (
-            catalog["st_name"].astype(str).str.strip().str.lstrip("* ").str.lower() == sci_norm
-        )
-        match = catalog[mask]
-        if not match.empty:
-            val = safe_float(match.iloc[0].get(mag_col))
-            if val is not None:
-                print(f"  Science target {band_label}-band mag: {val:.2f} (from catalog)")
-                return val
-
-    # 2) Fall back to fetch_star.php (the individual-star endpoint)
     try:
-        import requests, numpy as np, pandas as pd
         url = "https://corgidb.sioslab.com/fetch_star.php"
         resp = requests.get(
             url,
@@ -750,7 +731,7 @@ def select_ref_star(
     candidates = candidates.dropna(subset=[mag_col])
     candidates["grade_rank"] = candidates["grade"].map(grade_rank_map).fillna(99).astype(int)
 
-    print(f"  Grade filter {active_grades}: {len(candidates)} candidate(s) remaining.")
+    print(f"  Grade filter {active_grades}: {len(candidates)} candidate(s) remaining (sourced from CORGI database).")
 
     print(f"Querying SIMBAD for '{sci_name}'...")
     coords = get_target_coords([sci_name])
@@ -760,7 +741,7 @@ def select_ref_star(
     print(f"  Found '{sci_name}'.")
 
     print(f"Looking up {band_label}-band magnitude for '{sci_name}'...")
-    sci_mag = get_science_mag(sci_name, band, catalog=catalog)
+    sci_mag = get_science_mag(sci_name, band)
 
     print(f"Looking up diameter for '{sci_name}' from VizieR JSDC v2...")
     sci_diameter, sci_diameter_src = get_science_target_diameter(sci_name, sci_coord, band)
@@ -808,7 +789,7 @@ def select_ref_star(
     )
     sci_pitch_vals = sci_pitch_full.to(u.degree).value
 
-    print("Building reference star coordinates...")
+    print("Building reference star coordinates from CORGI catalog...")
     ref_coords = {}
     for _, ref in candidates.iterrows():
         name = ref["main_id"]

--- a/src/roman_pointing/Reference_Star_Selection_Tool.py
+++ b/src/roman_pointing/Reference_Star_Selection_Tool.py
@@ -397,20 +397,20 @@ def load_catalog(
     resolved_cache = Path(cache_path) if cache_path else DEFAULT_CACHE_PATH
 
     if not force_refresh and cache_is_fresh(resolved_cache, max_cache_age_hours):
-        print(f"Loading CORGI reference star catalog from cache ({resolved_cache.name})...")
+        print(f"Loading CORGIDB reference star catalog from cache ({resolved_cache.name})...")
         df = pd.read_csv(resolved_cache, low_memory=False)
-        print(f"  CORGI catalog loaded: {len(df)} reference star(s).")
+        print(f"  CORGIDB catalog loaded: {len(df)} reference star(s).")
         return df
 
     fetch_error = None
-    print(f"Fetching CORGI reference star catalog from {url} ...")
+    print(f"Fetching CORGIDB reference star catalog from {url} ...")
     try:
         df = fetch_catalog(url)
         df = coerce_catalog(df)
         resolved_cache.parent.mkdir(parents=True, exist_ok=True)
         df.to_csv(resolved_cache, index=False)
-        print(f"  CORGI catalog cached → {resolved_cache}")
-        print(f"  CORGI catalog loaded: {len(df)} reference star(s).")
+        print(f"  CORGIDB catalog cached → {resolved_cache}")
+        print(f"  CORGIDB catalog loaded: {len(df)} reference star(s).")
         return df
     except Exception as exc:
         fetch_error = exc
@@ -423,7 +423,7 @@ def load_catalog(
             stacklevel=2,
         )
         df = pd.read_csv(resolved_cache, low_memory=False)
-        print(f"  CORGI catalog loaded from stale cache: {len(df)} reference star(s).")
+        print(f"  CORGIDB catalog loaded from stale cache: {len(df)} reference star(s).")
         return df
 
     raise RuntimeError(
@@ -521,7 +521,6 @@ def build_skycoord(star):
         kwargs["radial_velocity"] = get_field("st_radv") * u.km / u.s
 
     return c.SkyCoord(**kwargs).transform_to(c.BarycentricMeanEcliptic)
-
 
 
 def get_observable_windows(times, keepout_array):
@@ -731,14 +730,13 @@ def select_ref_star(
     candidates = candidates.dropna(subset=[mag_col])
     candidates["grade_rank"] = candidates["grade"].map(grade_rank_map).fillna(99).astype(int)
 
-    print(f"  Grade filter {active_grades}: {len(candidates)} candidate(s) remaining (sourced from CORGI database).")
+    print(f"  Grade filter {active_grades}: {len(candidates)} candidate(s) remaining (sourced from CORGIDB database).")
 
-    print(f"Querying SIMBAD for '{sci_name}'...")
+    print(f"Looking up coordinates for '{sci_name}' via CORGIDB StarAliases (SIMBAD fallback if not found)...")
     coords = get_target_coords([sci_name])
     if sci_name not in coords:
-        return {"error": f"Science target '{sci_name}' not found in SIMBAD."}
+        return {"error": f"Science target '{sci_name}' not found in CORGIDB or SIMBAD."}
     sci_coord = coords[sci_name]
-    print(f"  Found '{sci_name}'.")
 
     print(f"Looking up {band_label}-band magnitude for '{sci_name}'...")
     sci_mag = get_science_mag(sci_name, band)
@@ -789,7 +787,7 @@ def select_ref_star(
     )
     sci_pitch_vals = sci_pitch_full.to(u.degree).value
 
-    print("Building reference star coordinates from CORGI catalog...")
+    print("Building reference star coordinates from CORGIDB catalog...")
     ref_coords = {}
     for _, ref in candidates.iterrows():
         name = ref["main_id"]

--- a/src/roman_pointing/roman_observability.py
+++ b/src/roman_pointing/roman_observability.py
@@ -8,6 +8,7 @@ import matplotlib
 import matplotlib.dates as mdates
 import matplotlib.pyplot as plt
 import numpy as np
+import requests
 from astropy.coordinates import BarycentricMeanEcliptic, Distance, SkyCoord
 from astropy.time import Time
 from astroquery.simbad import Simbad
@@ -20,29 +21,47 @@ from roman_pointing.roman_pointing import (
 
 
 def get_target_coords(target_names):
-    """Query SIMBAD for astronomical target coordinates and proper motions.
+    """Resolve target names to BarycentricMeanEcliptic SkyCoords.
 
-    Retrieves celestial coordinates, parallax, proper motion, and radial velocity
-    data from SIMBAD database for specified astronomical objects. Transforms
-    coordinates to Barycentric Mean Ecliptic frame for Roman Space Telescope
-    pointing calculations.
+    Retrieves celestial coordinates, proper motion, parallax, and radial
+    velocity for each target and transforms them to the Barycentric Mean
+    Ecliptic frame for Roman Space Telescope pointing calculations.
+
+    Resolution order for each target:
+        1. CORGIDB fetch_star.php endpoint (StarAliases table lookup).
+        2. SIMBAD (fallback if not found in CORGIDB).
+        3. Hardcoded galactic bulge coordinates (for names containing 'bulge').
 
     Args:
-        target_names (list of str): List of astronomical object names recognizable
-            by SIMBAD (e.g., 'Proxima Cen', 'Sirius', 'Betelgeuse'). Target names
-            containing 'bulge' will use hardcoded galactic
-            bulge coordinates.
+        target_names (list of str): Target names or registered CORGIDB/SIMBAD
+            aliases (e.g. '47 UMa', 'eps Eri'). Names containing 'bulge'
+            use hardcoded galactic bulge coordinates.
 
     Returns:
-        dict: Dictionary mapping target names (str) to astropy SkyCoord objects in
-            BarycentricMeanEcliptic frame. Targets not found in SIMBAD are
-            excluded from the returned dictionary.
+        dict: Dictionary mapping target name (str) to astropy SkyCoord in
+            BarycentricMeanEcliptic frame. Targets not resolved by either
+            CORGIDB or SIMBAD are omitted from the returned dictionary.
 
     Note:
-        This function prints a message to stdout when a target cannot be found
-        in SIMBAD. Special handling exists for galactic bulge targets. Any missing
-        proper motion/radial velocity data will be set to 0
+        Prints a message to stdout for each target indicating whether it was
+        found in CORGIDB, fell back to SIMBAD, or could not be resolved.
+        Missing proper motion and radial velocity values are set to zero.
+        The only component not queried from CORGIDB is science target angular
+        diameter, found in VizieR JSDC v2.
     """
+    _CORGI_COLS = [
+        "st_name", "main_id", "ra", "dec", "spectype",
+        "sy_vmag", "sy_imag", "sy_dist", "sy_plx",
+        "sy_pmra", "sy_pmdec", "st_radv",
+    ]
+
+    def _try_float(val):
+        try:
+            v = float(val)
+            return None if np.isnan(v) else v
+        except (TypeError, ValueError):
+            return None
+
     simbad = Simbad()
     simbad.add_votable_fields("pmra", "pmdec", "plx_value", "rvz_radvel")
     coords = {}
@@ -63,6 +82,56 @@ def get_target_coords(target_names):
             ).transform_to(BarycentricMeanEcliptic)
             continue
 
+        # Try CORGIDB StarAliases table first
+        try:
+            resp = requests.get(
+                "https://corgidb.sioslab.com/fetch_star.php",
+                headers={"User-Agent": "RomanRefStarPicker/1.0"},
+                params={"st_name": name},
+                timeout=15,
+            )
+            resp.raise_for_status()
+            raw = resp.json()
+            if raw:
+                data = np.vstack(raw).transpose()
+                row = {
+                    col: data[i][0]
+                    for i, col in enumerate(_CORGI_COLS)
+                    if i < len(data)
+                }
+                ra = _try_float(row.get("ra"))
+                dec = _try_float(row.get("dec"))
+                if ra is not None and dec is not None:
+                    print(f"  Found '{name}' in CORGIDB (StarAliases lookup).")
+                    sc_kwargs = dict(
+                        ra=ra * u.degree,
+                        dec=dec * u.degree,
+                        frame="icrs",
+                        equinox="J2000",
+                        obstime="J2000",
+                    )
+                    plx = _try_float(row.get("sy_plx"))
+                    dist = _try_float(row.get("sy_dist"))
+                    if plx:
+                        sc_kwargs["distance"] = Distance(parallax=plx * u.mas)
+                    elif dist:
+                        sc_kwargs["distance"] = dist * u.pc
+                    pmra = _try_float(row.get("sy_pmra"))
+                    pmdec = _try_float(row.get("sy_pmdec"))
+                    radv = _try_float(row.get("st_radv"))
+                    if pmra:
+                        sc_kwargs["pm_ra_cosdec"] = pmra * u.mas / u.yr
+                    if pmdec:
+                        sc_kwargs["pm_dec"] = pmdec * u.mas / u.yr
+                    if radv:
+                        sc_kwargs["radial_velocity"] = radv * u.km / u.s
+                    coords[name] = SkyCoord(**sc_kwargs).transform_to(BarycentricMeanEcliptic)
+                    continue
+        except (requests.RequestException, ValueError, KeyError):
+            pass
+
+        # Fall back to SIMBAD
+        print(f"  '{name}' not found in CORGIDB — querying SIMBAD...")
         res = simbad.query_object(name)
         if len(res) == 0:
             print(f"SIMBAD could not find {name}. Skipping.")
@@ -893,7 +962,7 @@ HD 209458
                 print(f"Processing {len(target_names)} targets...")
 
                 coords = get_target_coords(target_names)
-                print(f" {len(coords)} found in SIMBAD")
+                print(f" {len(coords)} target(s) resolved (via CORGIDB/SIMBAD)")
 
                 if not coords:
                     print(" No valid targets found.")
@@ -955,7 +1024,7 @@ HD 209458
                 print(f"Processing {len(target_names)} targets...")
 
                 coords = get_target_coords(target_names)
-                print(f" {len(coords)} found in SIMBAD")
+                print(f" {len(coords)} target(s) resolved (via CORGIDB/SIMBAD)")
 
                 if not coords:
                     print(" No valid targets found.")


### PR DESCRIPTION
Added the querying for the stars themselves (science targets) specifically for the fields: st_name, main_id, ra, dec, spectype, sy_vmag, sy_imag, sy_dist, sy_plx, sy_pmra, sy_pmdec, st_radv. If any of those fields are not found in the database, it will fall back on using SIMBAD for querying. In addition made some of the exceptions more specific. Needs to be updated to use the query script from the corgidb repo.